### PR TITLE
Fixed item names with widgetInners

### DIFF
--- a/qml/ui/widgets/AltitudeSecondWidgetForm.ui.qml
+++ b/qml/ui/widgets/AltitudeSecondWidgetForm.ui.qml
@@ -45,7 +45,7 @@ BaseWidget {
     }
 
     Item {
-        id: second_altitude_Text
+        id: widgetInner
         anchors.fill: parent
 
         Text {
@@ -59,7 +59,7 @@ BaseWidget {
         }
 
         Text {
-            id: second_alt_glyph
+            id: widgetGlyph
             y: 0
             width: 40
             height: 18

--- a/qml/ui/widgets/AltitudeWidgetForm.ui.qml
+++ b/qml/ui/widgets/AltitudeWidgetForm.ui.qml
@@ -43,7 +43,7 @@ BaseWidget {
     }
 
     Item {
-        id: altitude_Text
+        id: widgetInner
         anchors.fill: parent
 
         Text {
@@ -56,7 +56,7 @@ BaseWidget {
         }
 
         Text {
-            id: alt_glyph
+            id: widgetGlyph
             y: 0
             width: 40
             height: 18

--- a/qml/ui/widgets/FpvWidgetForm.ui.qml
+++ b/qml/ui/widgets/FpvWidgetForm.ui.qml
@@ -34,7 +34,7 @@ BaseWidget {
         antialiasing: true
 
         Text {
-            id: fpv_glyph
+            id: widgetGlyph
             y: 0
             width: 24
             height: 24

--- a/qml/ui/widgets/HeadingWidgetForm.ui.qml
+++ b/qml/ui/widgets/HeadingWidgetForm.ui.qml
@@ -60,7 +60,7 @@ BaseWidget {
         antialiasing: true
 
         Text {
-            id: hdg_glyph
+            id: widgetGlyph
             y: 0
             width: 30
             height: 18

--- a/qml/ui/widgets/SpeedWidgetForm.ui.qml
+++ b/qml/ui/widgets/SpeedWidgetForm.ui.qml
@@ -44,7 +44,7 @@ BaseWidget {
     }
 
     Item {
-        id: speed_Text
+        id: widgetInner
         anchors.fill: parent
 
         Text {
@@ -59,7 +59,7 @@ BaseWidget {
         }
 
         Text {
-            id: speed_glyph
+            id: widgetGlyph
             y: 0
             width: 40
             height: 18


### PR DESCRIPTION
All widgets I touched have the appropriate "widgetInner" id. Everything tested and wiggles!

Added "widgetGlyph" consistently across applicable widgets as a naming convention