### PR TITLE
Add save settings indicator

### DIFF
--- a/inc/openhdsettings.h
+++ b/inc/openhdsettings.h
@@ -46,8 +46,11 @@ signals:
     void allSettingsChanged(VMap allSettings);
     void loadingChanged(bool loading);
     void savingChanged(bool saving);
+    void savedChanged(bool saved);
+
     void savingSettingsStart();
-    void savingSettingsFinish();
+    void savingSettingsFinished();
+    void savingSettingsFailed(qint64 failCount);
 
     void groundStationIPUpdated(QString address);
 
@@ -56,23 +59,27 @@ signals:
 public slots:
     void processDatagrams();
 
-
-private slots:
-    void _savingSettingsStart();
-    void _savingSettingsFinish();
-
 private:
     void init();
     void _saveSettings(VMap remoteSettings);
+
     QUdpSocket *settingSocket = nullptr;
 
     bool m_ground_available = false;
 
     VMap m_allSettings;
-    qint64 start = 0;
-    QTimer timer;
-    void checkSettingsLoadTimeout();
 
+    qint64 loadStart = 0;
+
+    qint64 saveStart = 0;
+
+    QTimer loadTimer;
+    QTimer saveTimer;
+
+    void checkSettingsLoadTimeout();
+    void checkSettingsSaveTimeout();
+
+    QTimer savedTimer;
 
     // used to keep track of how many settings need to be saved so we can compare it to
     // the number of save confirmations we get back from the ground side

--- a/qml/ui/GroundPiSettingsPanel.ui.qml
+++ b/qml/ui/GroundPiSettingsPanel.ui.qml
@@ -8,6 +8,8 @@ import OpenHD 1.0
 
 Item {
     property alias save: save
+    property alias showSavedCheckmark: savedCheckmark.visible
+
     Layout.fillHeight: true
     Layout.fillWidth: true
 
@@ -196,6 +198,38 @@ Item {
             anchors.rightMargin: 0
             running: openHDSettings.loading || openHDSettings.saving
             visible: openHDSettings.loading || openHDSettings.saving
+        }
+
+        Item {
+            id: savedCheckmark
+            visible: false
+
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.right: button_row.left
+            anchors.rightMargin: 0
+
+            Text {
+                id: savedText
+                text: "saved"
+                font.pixelSize: 20
+                height: parent.height
+                anchors.right: savedIcon.left
+                anchors.rightMargin: 12
+                horizontalAlignment: Text.AlignRight
+                verticalAlignment: Text.AlignVCenter
+            }
+
+            Text {
+                id: savedIcon
+                text: "\uf00c"
+                font.family: "Font Awesome 5 Free"
+                font.pixelSize: 20
+                height: parent.height
+                anchors.right: parent.right
+                anchors.rightMargin: 0
+                horizontalAlignment: Text.AlignRight
+                verticalAlignment: Text.AlignVCenter
+            }
         }
     }
 }

--- a/qml/ui/SettingsPopup.qml
+++ b/qml/ui/SettingsPopup.qml
@@ -81,6 +81,36 @@ SettingsPopupForm {
         id: settingsMap
     }
 
+    Connections {
+        target: openHDSettings
+
+        onSavingSettingsStart: {
+            localMessage("saving ground settings...", 3);
+        }
+
+        onSavingSettingsFinished: {
+            localMessage("ground settings saved", 3);
+            showSavedCheckmark = true
+            savedTimer.start()
+        }
+
+        onSavingSettingsFailed: {
+            localMessage("%1 ground settings did not save!".arg(failCount), 4);
+            showSavedCheckmark = true
+        }
+    }
+
+    Timer {
+        id: savedTimer
+        running: false
+        interval: 5000
+        repeat: false
+        onTriggered: {
+            showSavedCheckmark = false
+        }
+
+    }
+
     /*Connections {
         target: openHDRC
         onSelectedGamepadChanged: {
@@ -290,15 +320,21 @@ SettingsPopupForm {
     }
 
     rebootButton.onClicked: {
+        savedTimer.stop()
+        showSavedCheckmark = false
         settings_popup.close();
         rebootDialog.open()
     }
 
     closeButton.onClicked: {
+        savedTimer.stop()
+        showSavedCheckmark = false
         settings_popup.close();
     }
 
     save.onClicked: {
+        savedTimer.stop()
+        showSavedCheckmark = false
         writeRemoteSettings();
     }
 

--- a/qml/ui/SettingsPopupForm.ui.qml
+++ b/qml/ui/SettingsPopupForm.ui.qml
@@ -13,6 +13,7 @@ import "../ui" as Ui
 
 Popup {
     property alias save: groundPiSettingsPanel.save
+    property alias showSavedCheckmark: groundPiSettingsPanel.showSavedCheckmark
     property alias settings_popup: settings_popup
     property alias closeButton: closeButton
     property alias rebootButton: rebootButton

--- a/src/openhdsettings.cpp
+++ b/src/openhdsettings.cpp
@@ -4,6 +4,8 @@
 #include <QThread>
 #include <QtConcurrent>
 
+#include "localmessage.h"
+
 #define SETTINGS_PORT 1011
 #define SETTINGS_IP "192.168.2.1"
 
@@ -19,11 +21,8 @@ void OpenHDSettings::initSettings() {
     settingSocket->bind(QHostAddress::Any, 5115);
     connect(settingSocket, SIGNAL(readyRead()), this, SLOT(processDatagrams()));
 
-    connect(&timer, &QTimer::timeout, this, &OpenHDSettings::checkSettingsLoadTimeout);
-
-    // internal signal from background thread
-    connect(this, &OpenHDSettings::savingSettingsStart, this, &OpenHDSettings::_savingSettingsStart);
-    connect(this, &OpenHDSettings::savingSettingsFinish, this, &OpenHDSettings::_savingSettingsFinish);
+    connect(&loadTimer, &QTimer::timeout, this, &OpenHDSettings::checkSettingsLoadTimeout);
+    connect(&saveTimer, &QTimer::timeout, this, &OpenHDSettings::checkSettingsSaveTimeout);
 }
 
 void OpenHDSettings::set_ground_available(bool ground_available) {
@@ -41,15 +40,33 @@ void OpenHDSettings::set_saving(bool saving) {
     emit savingChanged(m_saving);
 }
 
+
 void OpenHDSettings::checkSettingsLoadTimeout() {
     qint64 current = QDateTime::currentSecsSinceEpoch();
     //fallback in case the ground pi never sends back "ConfigEnd=ConfigEnd"
-    if (current - start > 30) {
-        timer.stop();
-        emit allSettingsChanged(m_allSettings);
+    if (current - loadStart > 30) {
+        loadTimer.stop();
         set_loading(false);
+        emit allSettingsChanged(m_allSettings);
     }
 }
+
+
+void OpenHDSettings::checkSettingsSaveTimeout() {
+    qint64 current = QDateTime::currentSecsSinceEpoch();
+    //fallback in case the ground pi never sends back "SavedGround" for all
+    // the settings we saved
+    if (current - saveStart > 30) {
+        saveTimer.stop();
+        set_saving(false);
+        if (settingsCount <= 0) {
+            emit savingSettingsFinished();
+        } else {
+            emit savingSettingsFailed(settingsCount);
+        }
+    }
+}
+
 
 void OpenHDSettings::reboot() {
     if (m_saving) {
@@ -81,14 +98,6 @@ void OpenHDSettings::shutdown() {
 }
 
 
-void OpenHDSettings::_savingSettingsStart() {
-    set_saving(true);
-}
-
-void OpenHDSettings::_savingSettingsFinish() {
-    set_saving(false);
-}
-
 void OpenHDSettings::saveSettings(VMap remoteSettings) {
     qDebug() << "OpenHDSettings::saveSettings()";
 
@@ -103,9 +112,19 @@ void OpenHDSettings::_saveSettings(VMap remoteSettings) {
         return;
     }
     set_saving(true);
-    //emit savingSettingsStart();
+
+    emit savingSettingsStart();
+
+    QUdpSocket *s = new QUdpSocket(this);
+#if defined(__rasp_pi__)
+    s->connectToHost(SETTINGS_IP, SETTINGS_PORT);
+#else
+    s->connectToHost(groundAddress, SETTINGS_PORT);
+#endif
 
     settingsCount = remoteSettings.count();
+    saveStart = QDateTime::currentSecsSinceEpoch();
+    saveTimer.start(1000);
 
     QMapIterator<QString, QVariant> i(remoteSettings);
     while (i.hasNext()) {
@@ -119,9 +138,6 @@ void OpenHDSettings::_saveSettings(VMap remoteSettings) {
 
         QThread::msleep(30);
     }
-    set_saving(false);
-
-    //emit savingSettingsFinish();
 }
 
 VMap OpenHDSettings::getAllSettings() {
@@ -136,8 +152,8 @@ void OpenHDSettings::fetchSettings() {
 
     qDebug() << "OpenHDSettings::fetchSettings()";
 
-    start = QDateTime::currentSecsSinceEpoch();
-    timer.start(1000);
+    loadStart = QDateTime::currentSecsSinceEpoch();
+    loadTimer.start(1000);
 
     QByteArray r = QByteArray("RequestAllSettings");
     QNetworkDatagram d(r);
@@ -157,11 +173,16 @@ void OpenHDSettings::processDatagrams() {
         set_ground_available(true);
 
         if (datagram == "ConfigRespConfigEnd=ConfigEnd") {
-            timer.stop();
+            loadTimer.stop();
             emit allSettingsChanged(m_allSettings);
             set_loading(false);
         } else if (datagram.contains("SavedGround")) {
             settingsCount -= 1;
+            if (settingsCount <= 0) {
+                set_saving(false);
+                saveTimer.stop();
+                emit savingSettingsFinished();
+            }
         } else {
             auto set = datagram.split('=');
             auto key = set.first();         


### PR DESCRIPTION
This shows a "Saved" message next to the save button in settings once the ground station confirms that the settings were actually saved by sending back a "SavedGround" reply.

The message is displayed for 5 seconds and then removed.

There is also code in this PR to show a failure message, currently routed to the on-screen log but another small message could be added to the settings panel itself in the same place the "Saved" message appears.